### PR TITLE
fix: use post request instead of get for getUserData

### DIFF
--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -77,10 +77,9 @@ export async function loadContextData(session: SessionType): Promise<any> {
     .get<References>(KARRIO_API + '/v1/references', { headers })
     .then(({ data }) => data);
   const getUserData = () => axios
-    .get<ContextDataType>(KARRIO_API + '/graphql', {
-      headers,
-      data: { query: dataQuery(metadata) }
-    })
+    .post<ContextDataType>(KARRIO_API + '/graphql', 
+    { query: dataQuery(metadata) }, 
+    { headers })
     .then(({ data }) => data);
 
   try {


### PR DESCRIPTION
even if the specification is vague there are many services (e.g. loadblancer) that have difficulties with this if a GET request including a payload.
See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET

thats why i replaced it with a normal POST request