### PR TITLE
[patch] 2022.8.17

### DIFF
--- a/src/components/connect-provider-modal.tsx
+++ b/src/components/connect-provider-modal.tsx
@@ -245,6 +245,7 @@ const ConnectProviderModal: React.FC<ConnectProviderModalComponent> = ({ childre
                 />}
 
                 {field("check_word").exists && <InputField label="Check Word" value={payload.check_word} 
+                  type="text"
                   name="check_word" 
                   onChange={handleChange} 
                   className="is-small" 
@@ -266,6 +267,7 @@ const ConnectProviderModal: React.FC<ConnectProviderModalComponent> = ({ childre
                 />}
 
                 {field("password").exists && <InputField label="Password" value={payload.password} 
+                  type="text"
                   name="password" 
                   onChange={handleChange} 
                   className="is-small" 
@@ -273,6 +275,7 @@ const ConnectProviderModal: React.FC<ConnectProviderModalComponent> = ({ childre
                 />}
 
                 {field("client_secret").exists && <InputField label="Client Secret" value={payload.client_secret} 
+                  type="text"
                   name="client_secret" 
                   onChange={handleChange} 
                   className="is-small" 
@@ -301,6 +304,7 @@ const ConnectProviderModal: React.FC<ConnectProviderModalComponent> = ({ childre
                 />}
 
                 {field("consumer_secret").exists && <InputField label="Consumer Secret" value={payload.consumer_secret} 
+                  type="text"
                   name="consumer_secret" 
                   onChange={handleChange} 
                   className="is-small" 
@@ -315,6 +319,7 @@ const ConnectProviderModal: React.FC<ConnectProviderModalComponent> = ({ childre
                 />}
 
                 {field("api_secret").exists && <InputField label="API Secret" value={payload.api_secret} 
+                  type="text"
                   name="api_secret" 
                   onChange={handleChange} 
                   className="is-small" 

--- a/src/components/connect-provider-modal.tsx
+++ b/src/components/connect-provider-modal.tsx
@@ -106,10 +106,13 @@ const ConnectProviderModal: React.FC<ConnectProviderModalComponent> = ({ childre
     evt.preventDefault();
     setLoading(true);
     try {
-      const { carrier_name: _, __typename, id, capabilities, ...content } = payload;
+      const { carrier_name: _, __typename, id, capabilities, display_name, ...content } = payload;
       const settingsName = `${carrier_name}settings`.replace('_', '');
-      const data = { [settingsName]: content };
-      if (isNew) {
+      const data = { 
+        [settingsName]: settingsName.includes('generic') ? {...content, display_name} : content 
+      };
+      
+        if (isNew) {
         await createConnection(data);
       } else {
         await updateConnection({ id, ...data });

--- a/src/context/label-data-mutation.tsx
+++ b/src/context/label-data-mutation.tsx
@@ -258,9 +258,10 @@ const LabelMutationProvider: React.FC = ({ children }) => {
 
   // requests
   const fetchRates = async () => {
+    const { messages, rates, ...data } = shipment;
     try {
       loader.setLoading(true);
-      const { rates, messages } = await mutation.fetchRates(shipment);
+      const { rates, messages } = await mutation.fetchRates(data as ShipmentType);
       updateShipment({ rates, messages } as Partial<ShipmentType>);
     } catch (error: any) {
       updateShipment({ rates: [], messages: errorToMessages(error) } as Partial<ShipmentType>);
@@ -268,7 +269,7 @@ const LabelMutationProvider: React.FC = ({ children }) => {
     loader.setLoading(false);
   };
   const buyLabel = async (rate: ShipmentType['rates'][0]) => {
-    const { messages, ...data } = shipment;
+    const { messages, rates, ...data } = shipment;
     const selection = isDraft(shipment.id) ? {
       service: rate.service,
       carrier_ids: [rate.carrier_id],


### PR DESCRIPTION
- (fix) carrier settings update errors caused by read-only (display_name) field sent in the request
- (remove) noisy rates data sent back to the server during rate fetching and label purchase
- (fix) issue with password hashed and overridden by password managers on carrier settings